### PR TITLE
Added call to enablePageScrolling() in modal.destroy.

### DIFF
--- a/src/cui/components/modal/src/js/modal.js
+++ b/src/cui/components/modal/src/js/modal.js
@@ -251,6 +251,8 @@ define(['jquery', 'cui', 'guid', 'uiBox', 'uiPosition', 'css!modal'], function (
             }
 
             $window.off('resize', _events.resize);
+
+            _priv.enablePageScrolling();
         });
     };
 


### PR DESCRIPTION
Page scroll was only being re-enabled when modal.hide was called. Added call to re-enable page scroll on modal.destroy as well.