### PR TITLE
Default height and width values were being set as the other

### DIFF
--- a/src/cui/components/popover/src/js/popover.js
+++ b/src/cui/components/popover/src/js/popover.js
@@ -630,8 +630,8 @@ define(['jquery', 'cui', 'guid', 'withinviewport', 'uiBox', 'uiPosition'], funct
         }
 
         popover.$popover.css({
-                            height: defaultWidth,
-                            width: defaultHeight,
+                            width: defaultWidth,
+                            height: defaultHeight,
                         });
     };
 


### PR DESCRIPTION
Within the resize function the defaultHeight and defaultWidth were being used as the other for the popover css.