### PR TITLE
Commented out additional watch:styles calls in the main grunt config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -404,42 +404,42 @@ module.exports = function (grunt) {
             },
 
             // Core component styles
-            styles: {
-                files: [
-                    'src/cui/components/**/*.scss',
-                ],
-                tasks: [
-                    'clean',
-                    // 'md2html',
-                    // 'componentFinder',
-                    // 'copy',
-                    // 'svgmin',
-                    'sass',
-                    // 'requirejs',
-                    'concat:css',
-                    // 'copy',
-                    'usebanner',
-                ],
-            },
+            // styles: {
+            //     files: [
+            //         'src/cui/components/**/*.scss',
+            //     ],
+            //     tasks: [
+            //         'clean',
+            //         // 'md2html',
+            //         // 'componentFinder',
+            //         // 'copy',
+            //         // 'svgmin',
+            //         'sass',
+            //         // 'requirejs',
+            //         'concat:css',
+            //         // 'copy',
+            //         'usebanner',
+            //     ],
+            // },
 
-            // Core component scripts
-            styles: {
-                files: [
-                    'src/cui/components/**/*.scss',
-                ],
-                tasks: [
-                    'clean',
-                    // 'md2html',
-                    'componentFinder',
-                    // 'copy',
-                    // 'svgmin',
-                    // 'sass',
-                    'requirejs',
-                    'concat:js',
-                    // 'copy',
-                    'usebanner',
-                ],
-            },
+            // // Core component scripts
+            // styles: {
+            //     files: [
+            //         'src/cui/components/**/*.scss',
+            //     ],
+            //     tasks: [
+            //         'clean',
+            //         // 'md2html',
+            //         'componentFinder',
+            //         // 'copy',
+            //         // 'svgmin',
+            //         // 'sass',
+            //         'requirejs',
+            //         'concat:js',
+            //         // 'copy',
+            //         'usebanner',
+            //     ],
+            // },
 
             // Project HTML
             html: {


### PR DESCRIPTION
Through testing these duplicate 'styles' calls are what seem to have been causing the issues with the live reload feature. I am not sure if these calls were required, but my understanding of the build process is that each component should be defining their own watch settings in their internal grunt file. If these are not required the branch can be updated to remove instead of comment. 