### PR TITLE
Updates input mask show/hide control to prevent propagation of events…

### DIFF
--- a/src/cui/components/inputmask/src/js/inputmask.js
+++ b/src/cui/components/inputmask/src/js/inputmask.js
@@ -225,6 +225,7 @@ define(['jquery'], function ($) {
         if (evt.keyCode === 13 || evt.keyCode === 32) {
             config.cbox.checked = !config.cbox.checked;
             toggleMask(config);
+            evt.preventDefault();
         }
     };
 


### PR DESCRIPTION
… when space or enter key is used to trigger show/hide.

Previously if the space key was used to trigger the mask, the space would also be entered in the input field.