### PR TITLE
Fixes issue where popovers were not displaying properly in responsive views

### DIFF
--- a/src/cui/components/popover/src/js/popover.js
+++ b/src/cui/components/popover/src/js/popover.js
@@ -309,7 +309,8 @@ define(['jquery', 'cui', 'guid', 'withinviewport', 'uiBox', 'uiPosition'], funct
 
         popover.isShown = true;
 
-        if((typeof popover.config.location === 'string') && (popover.config.location.indexOf('below')!== -1)){
+        //If not positioned below and not set to resize on mobile
+        if((typeof popover.config.location === 'string') && (popover.config.location.indexOf('below')!== -1) && !popover.config.resizeMobile || (popover.config.resizeMobile && (window.innerWidth > MOBILE_BREAKPOINT))){
             priv.resetMaxHeight(popover);
             priv.resetSize(popover);
             priv.resetInnerContentHeight(popover);


### PR DESCRIPTION
Popovers set to display full size in responsive sizes would initially display small, and fill the screen only when the view-port was resized.